### PR TITLE
Update vivado_2019.2.json

### DIFF
--- a/catalog/vivado_2019.2.json
+++ b/catalog/vivado_2019.2.json
@@ -2407,15 +2407,28 @@
             "date": "28-05-2019:11:08:19", 
             "history": "Migrating Alveo latest board files from perforce/2019.1 to git"
           }, 
-          {
-            "revision": "1.1", 
-            "commit_id": "ff158172d435d82c4beefc0289e6831353144573", 
-            "date": "28-05-2019:11:08:43", 
-            "history": "Migrating Alveo latest board files from perforce/2019.1 to git"
-          }
         ], 
         "config": {
           "root": "boards/Xilinx/au280/es1/1.0", 
+          "metadata_file": "xitem.json"
+        }, 
+        "company": "xilinx.com"
+      }, 
+      {
+        "name": "au280_es1", 
+        "display": "Alveo U280-ES1 Data Center Accelerator Card", 
+        "latest_revision": "1.1", 
+        "commit_id": "ff158172d435d82c4beefc0289e6831353144573", 
+        "revisions": [
+          {
+            "revision": "1.1", 
+            "commit_id": "ff158172d435d82c4beefc0289e6831353144573", 
+            "date": "28-05-2019:11:08:19", 
+            "history": "Migrating Alveo latest board files from perforce/2019.1 to git"
+          }, 
+        ], 
+        "config": {
+          "root": "boards/Xilinx/au280/es1/1.1", 
           "metadata_file": "xitem.json"
         }, 
         "company": "xilinx.com"


### PR DESCRIPTION
Making entries separate for 1.0 and 1.1 version of alveo au280 es board files