### PR TITLE
Update to frequency parameter of sfp_si5328_clock

### DIFF
--- a/boards/Xilinx/zcu106/2.5/board.xml
+++ b/boards/Xilinx/zcu106/2.5/board.xml
@@ -869,7 +869,7 @@
 
 		<interface mode="slave" name="sfp_si5328_clock" type="xilinx.com:interface:diff_clock_rtl:1.0" of_component="sfp">
 			<parameters>
-				<parameter name="frequency" value="161132812"/>
+				<parameter name="frequency" value="156250000"/>
 			</parameters>
 			<preferred_ips>
 				<preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>


### PR DESCRIPTION
Changing clock frequency from 161.132812 to 156.25 MHz