### PR TITLE
Update vivado_2019.2.json

### DIFF
--- a/catalog/vivado_2019.2.json
+++ b/catalog/vivado_2019.2.json
@@ -2456,11 +2456,11 @@
         "name": "v350_es", 
         "display": "V350 ES0 Data Center Accelerator Card", 
         "latest_revision": "1.1", 
-        "commit_id": "f12830f5a81554c267533bde4d5c3fbef13982bd", 
+        "commit_id": "1799e899c11b7a1be628a3c43130f8c3ae633b1d", 
         "revisions": [
           {
             "revision": "1.1", 
-            "commit_id": "f12830f5a81554c267533bde4d5c3fbef13982bd", 
+            "commit_id": "1799e899c11b7a1be628a3c43130f8c3ae633b1d", 
             "date": "27-09-2019:20:07:54", 
             "history": "Adding v350 board support"
           }


### PR DESCRIPTION
Fixed typo : vck190 to v350 in readme.txt