### PR TITLE
Removing drive strength for MIO21 as default is 8mA

### DIFF
--- a/boards/Xilinx/vck190/es/1.4/preset.xml
+++ b/boards/Xilinx/vck190/es/1.4/preset.xml
@@ -35,7 +35,6 @@
 				</user_parameter>
 				<user_parameter name="PS_MIO21" value_type="hier" value="">
 					<user_parameter name="AUX_IO" value="0"/>
-					<user_parameter name="DRIVE_STRENGTH" value="8mA"/>
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="PULL" value="disable"/>
 					</user_parameter>

--- a/boards/Xilinx/vck190/production/2.3/preset.xml
+++ b/boards/Xilinx/vck190/production/2.3/preset.xml
@@ -35,7 +35,6 @@
 				</user_parameter>
 				<user_parameter name="PS_MIO21" value_type="hier" value="">
 					<user_parameter name="AUX_IO" value="0"/>
-					<user_parameter name="DRIVE_STRENGTH" value="8mA"/>
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="PULL" value="disable"/>
 					</user_parameter>

--- a/boards/Xilinx/vmk180/es/1.4/preset.xml
+++ b/boards/Xilinx/vmk180/es/1.4/preset.xml
@@ -35,7 +35,6 @@
 				</user_parameter>
 				<user_parameter name="PS_MIO21" value_type="hier" value="">
 					<user_parameter name="AUX_IO" value="0"/>
-					<user_parameter name="DRIVE_STRENGTH" value="8mA"/>
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="PULL" value="disable"/>
 					</user_parameter>

--- a/boards/Xilinx/vmk180/production/2.3/preset.xml
+++ b/boards/Xilinx/vmk180/production/2.3/preset.xml
@@ -35,7 +35,6 @@
 				</user_parameter>
 				<user_parameter name="PS_MIO21" value_type="hier" value="">
 					<user_parameter name="AUX_IO" value="0"/>
-					<user_parameter name="DRIVE_STRENGTH" value="8mA"/>
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="PULL" value="disable"/>
 					</user_parameter>


### PR DESCRIPTION
Removing drive strength for MIO21 as default is 8mA