### PR TITLE
Explicitly disabling SD0 interface for eMMC preset to fix CR-1115417

### DIFF
--- a/boards/Xilinx/vck190/production/2.3/preset.xml
+++ b/boards/Xilinx/vck190/production/2.3/preset.xml
@@ -394,6 +394,12 @@
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="USAGE" value="GPIO"/>
 				</user_parameter>
+				<user_parameter name="PMC_SD0_PERIPHERAL" value_type="hier" value="">
+				<user_parameter name="ENABLE" value="0"/>
+				<user_parameter name="IO" value_type="hier" value="">
+				<user_parameter name="PMC_MIO" value="13 .. 25"/>
+				</user_parameter>
+				</user_parameter>
 				<user_parameter name="PMC_SD1" value_type="hier" value="">
 					<user_parameter name="CD_ENABLE" value="0"/>
 					<user_parameter name="CD_IO" value_type="hier" value="">

--- a/boards/Xilinx/vck190_newl/production/1.0/preset.xml
+++ b/boards/Xilinx/vck190_newl/production/1.0/preset.xml
@@ -394,6 +394,12 @@
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="USAGE" value="GPIO"/>
 				</user_parameter>
+				<user_parameter name="PMC_SD0_PERIPHERAL" value_type="hier" value="">
+				<user_parameter name="ENABLE" value="0"/>
+				<user_parameter name="IO" value_type="hier" value="">
+				<user_parameter name="PMC_MIO" value="13 .. 25"/>
+				</user_parameter>
+				</user_parameter>
 				<user_parameter name="PMC_SD1" value_type="hier" value="">
 					<user_parameter name="CD_ENABLE" value="0"/>
 					<user_parameter name="CD_IO" value_type="hier" value="">

--- a/boards/Xilinx/vmk180/production/2.3/preset.xml
+++ b/boards/Xilinx/vmk180/production/2.3/preset.xml
@@ -395,6 +395,12 @@
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="USAGE" value="GPIO"/>
 				</user_parameter>
+				<user_parameter name="PMC_SD0_PERIPHERAL" value_type="hier" value="">
+				<user_parameter name="ENABLE" value="0"/>
+				<user_parameter name="IO" value_type="hier" value="">
+				<user_parameter name="PMC_MIO" value="13 .. 25"/>
+				</user_parameter>
+				</user_parameter>
 				<user_parameter name="PMC_SD1" value_type="hier" value="">
 					<user_parameter name="CD_ENABLE" value="0"/>
 					<user_parameter name="CD_IO" value_type="hier" value="">

--- a/boards/Xilinx/vmk180_newl/production/1.0/preset.xml
+++ b/boards/Xilinx/vmk180_newl/production/1.0/preset.xml
@@ -394,6 +394,12 @@
 					<user_parameter name="OUTPUT_DATA" value="high"/>
 					<user_parameter name="USAGE" value="GPIO"/>
 				</user_parameter>
+				<user_parameter name="PMC_SD0_PERIPHERAL" value_type="hier" value="">
+				<user_parameter name="ENABLE" value="0"/>
+				<user_parameter name="IO" value_type="hier" value="">
+				<user_parameter name="PMC_MIO" value="13 .. 25"/>
+				</user_parameter>
+				</user_parameter>
 				<user_parameter name="PMC_SD1" value_type="hier" value="">
 					<user_parameter name="CD_ENABLE" value="0"/>
 					<user_parameter name="CD_IO" value_type="hier" value="">


### PR DESCRIPTION
Explicitly disabling SD0 interface for eMMC preset to fix CR-1115417