### PR TITLE
Patch Opal Kelly SZG companion card xitems

### DIFF
--- a/boards/OpalKelly/SZG-ENET1G/1.0/xitem.json
+++ b/boards/OpalKelly/SZG-ENET1G/1.0/xitem.json
@@ -3,7 +3,7 @@
     "items": [
       {
         "infra": {
-          "name": "SZG_ENET1G Peripheral",
+          "name": "SZG_ENET1G",
           "display": "SZG_ENET1G Peripheral",
           "revision": "1.0",
           "description": "SZG_ENET1G Peripheral",

--- a/boards/OpalKelly/SZG-MIPI-8320/1.0/xitem.json
+++ b/boards/OpalKelly/SZG-MIPI-8320/1.0/xitem.json
@@ -3,7 +3,7 @@
     "items": [
       {
         "infra": {
-          "name": "SZG_MIPI_8320 Peripheral",
+          "name": "SZG_MIPI_8320",
           "display": "SZG_MIPI_8320 Peripheral",
           "revision": "1.0",
           "description": "SZG_MIPI_8320 Peripheral",

--- a/boards/OpalKelly/SZG-PCIEX4/1.0/xitem.json
+++ b/boards/OpalKelly/SZG-PCIEX4/1.0/xitem.json
@@ -3,7 +3,7 @@
     "items": [
       {
         "infra": {
-          "name": "SZG_PCIEX4 Peripheral",
+          "name": "SZG_PCIEX4",
           "display": "SZG_PCIEX4 Peripheral",
           "revision": "1.0",
           "description": "SZG_PCIEX4 Peripheral",


### PR DESCRIPTION
[XEM8320-AU25P Official Development Platform](https://www.xilinx.com/products/boards-and-kits/1-1ihf3st.html)
[XEM8320-AU25P Vivado Board File Doc](https://docs.opalkelly.com/xem8320/vivado-board-file/)

Using a space within the "name" attribute breaks the following command
that is used to install these board files:
`xhub::install [xhub::get_xitems opalkelly.com:xilinx_board_store:SZG_ENET1G Peripheral:1.0]`
Remove " Peripheral" entirely from the "name" attribute within the xitems.