### PR TITLE
Patch Opal Kelly SZG companion card xitems

### DIFF
--- a/boards/OpalKelly/SZG-ENET1G/1.0/board.xml
+++ b/boards/OpalKelly/SZG-ENET1G/1.0/board.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
-<board schema_version="2.2" vendor="opalkelly.com" name="szg_enet1g" display_name="SZG_ENET1G" url="https://docs.opalkelly.com/syzygy-peripherals/szg-enet1g/" preset_file="preset.xml" supports_ced="false">
+<board schema_version="2.2" vendor="opalkelly.com" name="SZG_ENET1G" display_name="SZG_ENET1G Peripheral" url="https://docs.opalkelly.com/syzygy-peripherals/szg-enet1g/" preset_file="preset.xml" supports_ced="false">
     <file_version>1.0</file_version> 
     
     <description>SZG_ENET1G Peripheral</description>

--- a/boards/OpalKelly/SZG-ENET1G/1.0/xitem.json
+++ b/boards/OpalKelly/SZG-ENET1G/1.0/xitem.json
@@ -3,21 +3,21 @@
     "items": [
       {
         "infra": {
-          "name": "SZG_ENET1G Peripheral",
-          "display": "SZG_ENET1G Peripheral",
-          "revision": "1.0",
-          "description": "SZG_ENET1G Peripheral",
-          "company": "opalkelly.com",
-          "company_display": "Opal Kelly",
-          "author": "Opal Kelly",
+          "name": "SZG_ENET1G", 
+          "display": "SZG_ENET1G Peripheral", 
+          "revision": "1.0", 
+          "description": "SZG_ENET1G Peripheral", 
+          "company": "opalkelly.com", 
+          "company_display": "Opal Kelly", 
+          "author": "Opal Kelly", 
           "contributors": [
             {
-              "group": "Opal Kelly",
+              "group": "Opal Kelly", 
               "url": "https://opalkelly.com/"
             }
-          ],
-          "category": "FMCs & Accessories",
-          "website": "https://opalkelly.com/",
+          ], 
+          "category": "FMCs & Accessories", 
+          "website": "https://docs.opalkelly.com/syzygy-peripherals/szg-enet1g/", 
           "logo": "",
           "search-keywords": [
             "XEM8320-AU25P",

--- a/boards/OpalKelly/SZG-MIPI-8320/1.0/board.xml
+++ b/boards/OpalKelly/SZG-MIPI-8320/1.0/board.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
-<board schema_version="2.2" vendor="opalkelly.com" name="szg_mipi_8320" display_name="SZG_MIPI_8320" url="https://docs.opalkelly.com/syzygy-peripherals/szg-mipi-8320/" preset_file="preset.xml" supports_ced="false">
+<board schema_version="2.2" vendor="opalkelly.com" name="SZG_MIPI_8320" display_name="SZG_MIPI_8320 Peripheral" url="https://docs.opalkelly.com/syzygy-peripherals/szg-mipi-8320/" preset_file="preset.xml" supports_ced="false">
     <file_version>1.0</file_version> 
     
     <description>SZG_MIPI_8320 Peripheral</description>

--- a/boards/OpalKelly/SZG-MIPI-8320/1.0/xitem.json
+++ b/boards/OpalKelly/SZG-MIPI-8320/1.0/xitem.json
@@ -3,21 +3,21 @@
     "items": [
       {
         "infra": {
-          "name": "SZG_MIPI_8320 Peripheral",
-          "display": "SZG_MIPI_8320 Peripheral",
-          "revision": "1.0",
-          "description": "SZG_MIPI_8320 Peripheral",
-          "company": "opalkelly.com",
-          "company_display": "Opal Kelly",
-          "author": "Opal Kelly",
+          "name": "SZG_MIPI_8320", 
+          "display": "SZG_MIPI_8320 Peripheral", 
+          "revision": "1.0", 
+          "description": "SZG_MIPI_8320 Peripheral", 
+          "company": "opalkelly.com", 
+          "company_display": "Opal Kelly", 
+          "author": "Opal Kelly", 
           "contributors": [
             {
-              "group": "Opal Kelly",
+              "group": "Opal Kelly", 
               "url": "https://opalkelly.com/"
             }
-          ],
-          "category": "FMCs & Accessories",
-          "website": "https://opalkelly.com/",
+          ], 
+          "category": "FMCs & Accessories", 
+          "website": "https://docs.opalkelly.com/syzygy-peripherals/szg-mipi-8320/", 
           "logo": "",
           "search-keywords": [
             "XEM8320-AU25P",

--- a/boards/OpalKelly/SZG-PCIEX4/1.0/board.xml
+++ b/boards/OpalKelly/SZG-PCIEX4/1.0/board.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
-<board schema_version="2.2" vendor="opalkelly.com" name="szg_pciex4" display_name="SZG_PCIEX4" url="https://docs.opalkelly.com/syzygy-peripherals/szg-pciex4/" preset_file="preset.xml" supports_ced="false">
+<board schema_version="2.2" vendor="opalkelly.com" name="SZG_PCIEX4" display_name="SZG_PCIEX4 Peripheral" url="https://docs.opalkelly.com/syzygy-peripherals/szg-pciex4/" preset_file="preset.xml" supports_ced="false">
     <file_version>1.0</file_version> 
     
     <description>SZG_PCIEX4 Peripheral</description>

--- a/boards/OpalKelly/SZG-PCIEX4/1.0/xitem.json
+++ b/boards/OpalKelly/SZG-PCIEX4/1.0/xitem.json
@@ -3,21 +3,21 @@
     "items": [
       {
         "infra": {
-          "name": "SZG_PCIEX4 Peripheral",
-          "display": "SZG_PCIEX4 Peripheral",
-          "revision": "1.0",
-          "description": "SZG_PCIEX4 Peripheral",
-          "company": "opalkelly.com",
-          "company_display": "Opal Kelly",
-          "author": "Opal Kelly",
+          "name": "SZG_PCIEX4", 
+          "display": "SZG_PCIEX4 Peripheral", 
+          "revision": "1.0", 
+          "description": "SZG_PCIEX4 Peripheral", 
+          "company": "opalkelly.com", 
+          "company_display": "Opal Kelly", 
+          "author": "Opal Kelly", 
           "contributors": [
             {
-              "group": "Opal Kelly",
+              "group": "Opal Kelly", 
               "url": "https://opalkelly.com/"
             }
-          ],
-          "category": "FMCs & Accessories",
-          "website": "https://opalkelly.com/",
+          ], 
+          "category": "FMCs & Accessories", 
+          "website": "https://docs.opalkelly.com/syzygy-peripherals/szg-pciex4/", 
           "logo": "",
           "search-keywords": [
             "XEM8320-AU25P",


### PR DESCRIPTION
[XEM8320-AU25P Official Development Platform](https://www.xilinx.com/products/boards-and-kits/1-1ihf3st.html)
[XEM8320-AU25P Vivado Board File Doc](https://docs.opalkelly.com/xem8320/vivado-board-file/)

Using a space within the "name" attibute breaks the following command
that is used to install these board files:
`xhub::install [xhub::get_xitems opalkelly.com:xilinx_board_store:SZG_ENET1G Peripheral:1.0]`

`generate_xitem_json.py` was instead used to generate the xitems from
information pulled from `board.xml`. Changes were made in
`board.xml` for the desired names to be used in the xitem.