### PR TITLE
Remove lingering Opal Kelly xitems from catalog

### DIFF
--- a/catalog/vivado_2021.2.json
+++ b/catalog/vivado_2021.2.json
@@ -6215,63 +6215,6 @@
         "company": "xilinx.com"
       },
       {
-        "name": "SZG_ENET1G Peripheral",
-        "display": "SZG_ENET1G Peripheral",
-        "latest_revision": "1.0",
-        "commit_id": "b30e267592700dd6f8d01399a9cc8f905a736fed",
-        "revisions": [
-          {
-            "revision": "1.0",
-            "commit_id": "b30e267592700dd6f8d01399a9cc8f905a736fed",
-            "date": "14-02-2022:21:55:10",
-            "history": "Added board SZG_ENET1G Peripheral v1.0"
-          }
-        ],
-        "config": {
-          "root": "boards/OpalKelly/SZG-ENET1G/1.0",
-          "metadata_file": "xitem.json"
-        },
-        "company": "opalkelly.com"
-      },
-      {
-        "name": "SZG_MIPI_8320 Peripheral",
-        "display": "SZG_MIPI_8320 Peripheral",
-        "latest_revision": "1.0",
-        "commit_id": "b30e267592700dd6f8d01399a9cc8f905a736fed",
-        "revisions": [
-          {
-            "revision": "1.0",
-            "commit_id": "b30e267592700dd6f8d01399a9cc8f905a736fed",
-            "date": "14-02-2022:21:55:10",
-            "history": "Added board SZG_MIPI_8320 Peripheral v1.0"
-          }
-        ],
-        "config": {
-          "root": "boards/OpalKelly/SZG-MIPI-8320/1.0",
-          "metadata_file": "xitem.json"
-        },
-        "company": "opalkelly.com"
-      },
-      {
-        "name": "SZG_PCIEX4 Peripheral",
-        "display": "SZG_PCIEX4 Peripheral",
-        "latest_revision": "1.0",
-        "commit_id": "b30e267592700dd6f8d01399a9cc8f905a736fed",
-        "revisions": [
-          {
-            "revision": "1.0",
-            "commit_id": "b30e267592700dd6f8d01399a9cc8f905a736fed",
-            "date": "14-02-2022:21:55:10",
-            "history": "Added board SZG_PCIEX4 Peripheral v1.0"
-          }
-        ],
-        "config": {
-          "root": "boards/OpalKelly/SZG-PCIEX4/1.0",
-          "metadata_file": "xitem.json"
-        },
-        "company": "opalkelly.com"
-      },
-      {
         "name": "XEM8320-AU25P",
         "display": "XEM8320-AU25P Development Platform",
         "latest_revision": "1.1",


### PR DESCRIPTION
Commit 5ba4dfc47294c92aec32e043c7c0d57e97648710 patched the companion
card board files provided by Opal Kelly. This patch involved a name
change. xilinxgitops commited new entries for these xitems in
vivado_2021.2.json, but left the old entries. It is up to the xitem
owner to delete these entries from the catalog.