### PR TITLE
CR-1134934 - Update preset.xml

### DIFF
--- a/boards/Xilinx/vhk158/es/1.0/preset.xml
+++ b/boards/Xilinx/vhk158/es/1.0/preset.xml
@@ -169,7 +169,7 @@
 					</user_hier_parameter>
 				
 					<user_parameter name="SMON_INTERFACE_TO_USE" value="I2C"/>
-					<user_parameter name="PMC_REF_CLK_FREQMHZ" value="33.3333"/>
+					<user_parameter name="PMC_REF_CLK_FREQMHZ" value="33.333"/>
 					<user_parameter name="PS_GEN_IPI0_ENABLE" value="1"/>
 					<user_parameter name="PS_GEN_IPI0_MASTER" value="A72"/>
 					<user_parameter name="PS_GEN_IPI1_ENABLE" value="1"/>


### PR DESCRIPTION
Changing PMC_REF_CLK_FREQMHZ from 33.3333 MHz to 33.333 MHz to resolve OSPI booting issue