### PR TITLE
b2021.1 OpalKelly: Update XEM8350 Vendor URL to undercase

### DIFF
--- a/boards/OpalKelly/XEM8350-KU060-3E/1.0/board.xml
+++ b/boards/OpalKelly/XEM8350-KU060-3E/1.0/board.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<board schema_version="2.2" vendor="OpalKelly.com" name="XEM8350-KU060-3E" display_name="XEM8350-KU060-3E Integration Module" url="https://opalkelly.com/products/xem8350/" preset_file="preset.xml">
+<board schema_version="2.2" vendor="opalkelly.com" name="XEM8350-KU060-3E" display_name="XEM8350-KU060-3E Integration Module" url="https://opalkelly.com/products/xem8350/" preset_file="preset.xml">
   <images>
     <image name="XEM8350-Top.jpg" display_name="XEM8350-KU060-3E" sub_type="board">
       <description>XEM8350-KU060-3E Board File Image</description>

--- a/boards/OpalKelly/XEM8350-KU060-3E/1.0/xitem.json
+++ b/boards/OpalKelly/XEM8350-KU060-3E/1.0/xitem.json
@@ -7,7 +7,7 @@
           "display": "XEM8350-KU060-3E Integration Platform",
           "revision": "1.0",
           "description": "XEM8350-KU060-3E Integration Platform",
-          "company": "OpalKelly.com",
+          "company": "opalkelly.com",
           "company_display": "Opal Kelly",
           "author": "Opal Kelly",
           "contributors": [
@@ -21,7 +21,7 @@
           "logo": "XEM8350-Top.jpg",
           "search-keywords": [
             "XEM8350-KU060-3E",
-            "OpalKelly.com",
+            "opalkelly.com",
             "board",
             "KU060-3E",
             "Opal Kelly",

--- a/boards/OpalKelly/XEM8350-KU060/1.0/board.xml
+++ b/boards/OpalKelly/XEM8350-KU060/1.0/board.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<board schema_version="2.2" vendor="OpalKelly.com" name="XEM8350-KU060" display_name="XEM8350-KU060 Integration Module" url="https://opalkelly.com/products/xem8350/" preset_file="preset.xml">
+<board schema_version="2.2" vendor="opalkelly.com" name="XEM8350-KU060" display_name="XEM8350-KU060 Integration Module" url="https://opalkelly.com/products/xem8350/" preset_file="preset.xml">
   <images>
     <image name="XEM8350-Top.jpg" display_name="XEM8350-KU060" sub_type="board">
       <description>XEM8350-KU060 Board File Image</description>

--- a/boards/OpalKelly/XEM8350-KU060/1.0/xitem.json
+++ b/boards/OpalKelly/XEM8350-KU060/1.0/xitem.json
@@ -7,7 +7,7 @@
           "display": "XEM8350-KU060 Integration Platform",
           "revision": "1.0",
           "description": "XEM8350-KU060 Integration Platform",
-          "company": "OpalKelly.com",
+          "company": "opalkelly.com",
           "company_display": "Opal Kelly",
           "author": "Opal Kelly",
           "contributors": [
@@ -21,7 +21,7 @@
           "logo": "XEM8350-Top.jpg",
           "search-keywords": [
             "XEM8350-KU060",
-            "OpalKelly.com",
+            "opalkelly.com",
             "board",
             "KU060",
             "Opal Kelly",


### PR DESCRIPTION
This incorrectly categorizes the XEM8350 using the Vendor filter.