### PR TITLE
CR-1158643 - Updated board I/O standard to support MIPI interface ,Updated connector display name and website details 

### DIFF
--- a/boards/Xilinx/li-imx274-mipi-versal/1.0/board.xml
+++ b/boards/Xilinx/li-imx274-mipi-versal/1.0/board.xml
@@ -48,10 +48,10 @@
 		
 		<component name="txdsi" display_name="MIPI DSI Tx" type="chip" sub_type="chip" major_group="FMC">
 			<description>MIPI DSI Tx Subsystem to connect to LI-IMX274MIPI-FMC V1.0 FMC placed on ZCU102 HPC0 FMC Slot only</description>
-			<!-- <preferred_ips> -->
-			<!-- <preferred_ip vendor="xilinx.com" library="ip" name="mipi_dsi_tx_subsystem" order="0"/> -->
-			<!-- <preferred_ip vendor="xilinx.com" library="ip" name="mipi_dphy" order="1"/> -->
-			<!-- </preferred_ips> -->
+			<preferred_ips>
+			<preferred_ip vendor="xilinx.com" library="ip" name="mipi_dsi_tx_subsystem" order="0"/>
+			<preferred_ip vendor="xilinx.com" library="ip" name="mipi_dphy" order="1"/>
+			</preferred_ips>
 		</component>
 		
 		<component name="mipi_csi2_iic" display_name="MIPI CSI-2 IIC" type="chip" sub_type="chip" major_group="FMC">
@@ -218,8 +218,8 @@
 				<pin index="143" name=""/><!-- D23 -->
 				<pin index="144" name=""/><!-- D24 -->
 				<pin index="145" name=""/><!-- D25 -->
-				<pin index="146" name="fmc_hpc0_la26_p" iostandard="HSUL_12_DCI"/><!-- D26 -->
-				<pin index="147" name="fmc_hpc0_la26_n" iostandard="HSUL_12_DCI"></pin><!-- D27 -->
+				<pin index="146" name="fmc_hpc0_la26_p" iostandard="LVCMOS12"/><!-- D26 -->
+				<pin index="147" name="fmc_hpc0_la26_n" iostandard="LVCMOS12"></pin><!-- D27 -->
 				<pin index="148" name=""/><!-- D28 -->
 				<pin index="149" name=""/><!-- D29 -->
 				<pin index="150" name=""/><!-- D30 -->

--- a/boards/Xilinx/li-imx274-mipi-versal/1.0/xitem.json
+++ b/boards/Xilinx/li-imx274-mipi-versal/1.0/xitem.json
@@ -4,9 +4,9 @@
       {
         "infra": {
           "name": "LI-IMX274MIPI-FMC-Versal", 
-          "display": "FMC XM105 Debug Card", 
+          "display": "LI-IMX274MIPI-FMC Versal", 
           "revision": "1.0", 
-          "description": "FMC XM105 Debug Card", 
+          "description": "LI-IMX274MIPI-FMC Versal", 
           "company": "Leopardimaging", 
           "company_display": "Leopardimaging", 
           "author": "KondalRao", 
@@ -18,7 +18,7 @@
           ], 
           "category": "FMCs & Accessories",
           "logo": "",
-          "website": "www.xilinx.com/SOM", 
+          "website": "https://leopardimaging.com/product/li-imx274mipi-fmc/", 
           "search-keywords": [
             "FMC", 
             "xilinx.com", 

--- a/boards/Xilinx/li-imx274-mipi/1.0/xitem.json
+++ b/boards/Xilinx/li-imx274-mipi/1.0/xitem.json
@@ -4,9 +4,9 @@
       {
         "infra": {
           "name": "LI-IMX274MIPI-FMC", 
-          "display": "FMC XM105 Debug Card", 
+          "display": "LI-IMX274MIPI-FMC V1.0", 
           "revision": "1.0", 
-          "description": "FMC XM105 Debug Card", 
+          "description": "LI-IMX274MIPI-FMC V1.0", 
           "company": "Leopardimaging", 
           "company_display": "Leopardimaging", 
           "author": "KondalRao", 
@@ -18,7 +18,7 @@
           ], 
           "category": "FMCs & Accessories",
           "logo": "",
-          "website": "www.xilinx.com/SOM", 
+          "website": "https://www.leopardimaging.com/product/csi-2-mipi-modules-i-pex/li-imx274mipi-fmc/", 
           "search-keywords": [
             "FMC", 
             "xilinx.com", 

--- a/boards/Xilinx/vek280/es/rev_b/1.1/README.md
+++ b/boards/Xilinx/vek280/es/rev_b/1.1/README.md
@@ -2,3 +2,6 @@ Validate that the xcve2802-vsvh1760-2MP-e-S-es1 is available in your Vivado inst
 Please see details in the board lounge or in user guide UG973: Vivado Release Notes, Installation, and Licensing.
 
 For more information please refer to user guide UG994: Using the Platform Board Flow in IP Integrator.
+
+Note : As per the schematic, bank 705 & bank 706 are provided with 1.5v (VADJ_FMC), but board file sets these bank pin's I/O standard to support MIPI interface (requires 1.2v).
+       User needs to take care of bank 705 & 706 pins I/O standard, if the MIPI interface is added and used in the design through board connections.

--- a/boards/Xilinx/vek280/es/rev_b/1.1/part0_pins.xml
+++ b/boards/Xilinx/vek280/es/rev_b/1.1/part0_pins.xml
@@ -13,21 +13,21 @@
 	<pins>
 		<pin index="0" name="lpddr4_clk1_p" iostandard="DIFF_SSTL15" loc="AU11" />
 		<pin index="1" name="lpddr4_clk1_n" iostandard="DIFF_SSTL15" loc="AV11" />
-		<pin index="2" name="lpddr4_clk2_p" iostandard="DIFF_SSTL15" loc="AV31" />
-		<pin index="3" name="lpddr4_clk2_n" iostandard="DIFF_SSTL15" loc="AV32" />
-		<pin index="4" name="lpddr4_clk3_p" iostandard="DIFF_SSTL15" loc="AU38" />
-		<pin index="5" name="lpddr4_clk3_n" iostandard="DIFF_SSTL15" loc="AU39" />
+		<pin index="2" name="lpddr4_clk2_p" iostandard="DIFF_LVSTL06_12" loc="AV31" />
+		<pin index="3" name="lpddr4_clk2_n" iostandard="DIFF_LVSTL06_12" loc="AV32" />
+		<pin index="4" name="lpddr4_clk3_p" iostandard="DIFF_LVSTL06_12" loc="AU38" />
+		<pin index="5" name="lpddr4_clk3_n" iostandard="DIFF_LVSTL06_12" loc="AU39" />
 		
 		<pin index="6" name="uart1_bank401_tx" iostandard="LVCMOS33" loc="F31" />
 		<pin index="7" name="uart1_bank401_rx" iostandard="LVCMOS33" loc="E31" />
 		<pin index="8" name="sysctrl_uart_tx" iostandard="LVCMOS33" loc="F32" />
 		<pin index="9" name="sysctrl_uart_rx" iostandard="LVCMOS33" loc="E32" />
-		<pin index="12" name="gpio_pb_0" iostandard="LVCMOS15" loc="AV33" />
-		<pin index="13" name="gpio_pb_1" iostandard="LVCMOS15" loc="AU34" />
-		<pin index="14" name="gpio_dp_0" iostandard="LVCMOS15" loc="AR35" />
-		<pin index="15" name="gpio_dp_1" iostandard="LVCMOS15" loc="AP35" />
-		<pin index="16" name="gpio_dp_2" iostandard="LVCMOS15" loc="AP33" />
-		<pin index="17" name="gpio_dp_3" iostandard="LVCMOS15" loc="AN33" />
+		<pin index="12" name="gpio_pb_0" iostandard="LVCMOS12" loc="AV33" />
+		<pin index="13" name="gpio_pb_1" iostandard="LVCMOS12" loc="AU34" />
+		<pin index="14" name="gpio_dp_0" iostandard="LVCMOS12" loc="AR35" />
+		<pin index="15" name="gpio_dp_1" iostandard="LVCMOS12" loc="AP35" />
+		<pin index="16" name="gpio_dp_2" iostandard="LVCMOS12" loc="AP33" />
+		<pin index="17" name="gpio_dp_3" iostandard="LVCMOS12" loc="AN33" />
 		<pin index="18" name="gpio_led_0" iostandard="LVCMOS15" loc="AT12" />
 		<pin index="19" name="gpio_led_1" iostandard="LVCMOS15" loc="AT11" />
 		<pin index="20" name="gpio_led_2" iostandard="LVCMOS15" loc="AU13" />
@@ -36,14 +36,14 @@
 		<!-- <pin index="23"  name ="dc_pl_gpio_1" iostandard="LVCMOS15" loc="L34" />		 -->
 		<!-- <pin index="24"  name ="dc_pl_gpio_2" iostandard="LVCMOS15" loc="J36" /> -->
 		<!-- <pin index="25"  name ="dc_pl_gpio_3" iostandard="LVCMOS15" loc="K37" /> -->
-		<pin index="26" name="sysctlr_gpio_0" iostandard="LVCMOS15" loc="AM32" />
-		<pin index="27" name="sysctlr_gpio_1" iostandard="LVCMOS15" loc="AM31" />
-		<pin index="28" name="sysctlr_gpio_2" iostandard="LVCMOS15" loc="AN34" />
-		<pin index="29" name="sysctlr_gpio_3" iostandard="LVCMOS15" loc="AM34" />
-		<pin index="30" name="sysctlr_gpio_4" iostandard="LVCMOS15" loc="AN35" />
-		<pin index="31" name="sysctlr_gpio_5" iostandard="LVCMOS15" loc="AM35" />
-		<pin index="32" name="sysctlr_gpio_6" iostandard="LVCMOS15" loc="AN36" />
-		<pin index="33" name="sysctlr_gpio_7" iostandard="LVCMOS15" loc="AM36" />
+		<pin index="26" name="sysctlr_gpio_0" iostandard="LVCMOS12" loc="AM32" />
+		<pin index="27" name="sysctlr_gpio_1" iostandard="LVCMOS12" loc="AM31" />
+		<pin index="28" name="sysctlr_gpio_2" iostandard="LVCMOS12" loc="AN34" />
+		<pin index="29" name="sysctlr_gpio_3" iostandard="LVCMOS12" loc="AM34" />
+		<pin index="30" name="sysctlr_gpio_4" iostandard="LVCMOS12" loc="AN35" />
+		<pin index="31" name="sysctlr_gpio_5" iostandard="LVCMOS12" loc="AM35" />
+		<pin index="32" name="sysctlr_gpio_6" iostandard="LVCMOS12" loc="AN36" />
+		<pin index="33" name="sysctlr_gpio_7" iostandard="LVCMOS12" loc="AM36" />
 		<!-- <pin index="34"  name ="sysctlr_gpio_8" iostandard="LVCMOS15" loc="L30" />	 -->
 		<!-- <pin index="35"  name ="sysctlr_gpio_9" iostandard="LVCMOS15" loc="K30" />	 -->
 		<!-- <pin index="36"  name ="sysctlr_gpio_10" iostandard="LVCMOS15" loc="L31" />	 -->
@@ -189,74 +189,74 @@
 		<!-- <pin index="233"  name ="c0_ddr4_alert_n"    loc="AD43"/>	 -->
 		<!-- fmcp1 -->
 		
-		<pin index="82" name="fmcp1_la00_cc_n" iostandard="LVCMOS15" loc="AW37" />
-		<pin index="83" name="fmcp1_la00_cc_p" iostandard="LVCMOS15" loc="AV36" />
-		<pin index="84" name="fmcp1_la01_cc_n" iostandard="LVCMOS15" loc="AY40" />
-		<pin index="85" name="fmcp1_la01_cc_p" iostandard="LVCMOS15" loc="AW40" />
-		<pin index="86" name="fmcp1_la02_n" iostandard="LVCMOS15" loc="AT42" />
-		<pin index="87" name="fmcp1_la02_p" iostandard="LVCMOS15" loc="AR42" />
-		<pin index="88" name="fmcp1_la03_n" iostandard="LVCMOS15" loc="BB36" />
-		<pin index="89" name="fmcp1_la03_p" iostandard="LVCMOS15" loc="BA36" />
-		<pin index="90" name="fmcp1_la04_n" iostandard="LVCMOS15" loc="BA37" />
-		<pin index="91" name="fmcp1_la04_p" iostandard="LVCMOS15" loc="AY36" />
-		<pin index="92" name="fmcp1_la05_n" iostandard="LVCMOS15" loc="AT38" />
-		<pin index="93" name="fmcp1_la05_p" iostandard="LVCMOS15" loc="AR39" />
-		<pin index="94" name="fmcp1_la06_n" iostandard="LVCMOS15" loc="AT37" />
-		<pin index="95" name="fmcp1_la06_p" iostandard="LVCMOS15" loc="AR37" />
-		<pin index="96" name="fmcp1_la07_n" iostandard="LVCMOS15" loc="BA38" />
-		<pin index="97" name="fmcp1_la07_p" iostandard="LVCMOS15" loc="AY37" />
-		<pin index="98" name="fmcp1_la08_n" iostandard="LVCMOS15" loc="AW39" />
-		<pin index="99" name="fmcp1_la08_p" iostandard="LVCMOS15" loc="AV38" />
-		<pin index="100" name="fmcp1_la09_n" iostandard="LVCMOS15" loc="AT41" />
-		<pin index="101" name="fmcp1_la09_p" iostandard="LVCMOS15" loc="AR41" />
-		<pin index="102" name="fmcp1_la10_n" iostandard="LVCMOS15" loc="AT39" />
-		<pin index="103" name="fmcp1_la10_p" iostandard="LVCMOS15" loc="AR40" />
-		<pin index="104" name="fmcp1_la11_n" iostandard="LVCMOS15" loc="BB40" />
-		<pin index="105" name="fmcp1_la11_p" iostandard="LVCMOS15" loc="BA41" />
-		<pin index="106" name="fmcp1_la12_n" iostandard="LVCMOS15" loc="AW38" />
-		<pin index="107" name="fmcp1_la12_p" iostandard="LVCMOS15" loc="AV37" />
-		<pin index="108" name="fmcp1_la13_n" iostandard="LVCMOS15" loc="BA39" />
-		<pin index="109" name="fmcp1_la13_p" iostandard="LVCMOS15" loc="AY39" />
-		<pin index="110" name="fmcp1_la14_n" iostandard="LVCMOS15" loc="AW42" />
-		<pin index="111" name="fmcp1_la14_p" iostandard="LVCMOS15" loc="AV42" />
-		<pin index="112" name="fmcp1_la15_n" iostandard="LVCMOS15" loc="BB39" />
-		<pin index="113" name="fmcp1_la15_p" iostandard="LVCMOS15" loc="BB38" />
-		<pin index="114" name="fmcp1_la16_n" iostandard="LVCMOS15" loc="AY42" />
-		<pin index="115" name="fmcp1_la16_p" iostandard="LVCMOS15" loc="AY41" />
-		<pin index="116" name="fmcp1_la17_cc_n" iostandard="LVCMOS15" loc="AW30" />
-		<pin index="117" name="fmcp1_la17_cc_p" iostandard="LVCMOS15" loc="AV30" />
-		<pin index="118" name="fmcp1_la18_cc_n" iostandard="LVCMOS15" loc="AU36" />
-		<pin index="119" name="fmcp1_la18_cc_p" iostandard="LVCMOS15" loc="AU35" />
-		<pin index="120" name="fmcp1_la19_n" iostandard="LVCMOS15" loc="AR32" />
-		<pin index="121" name="fmcp1_la19_p" iostandard="LVCMOS15" loc="AP32" />
-		<pin index="122" name="fmcp1_la20_n" iostandard="LVCMOS15" loc="AT34" />
-		<pin index="123" name="fmcp1_la20_p" iostandard="LVCMOS15" loc="AR34" />
-		<pin index="124" name="fmcp1_la21_n" iostandard="LVCMOS15" loc="BB33" />
-		<pin index="125" name="fmcp1_la21_p" iostandard="LVCMOS15" loc="BA33" />
-		<pin index="126" name="fmcp1_la22_n" iostandard="LVCMOS15" loc="BB35" />
-		<pin index="127" name="fmcp1_la22_p" iostandard="LVCMOS15" loc="BB34" />
-		<pin index="128" name="fmcp1_la23_n" iostandard="LVCMOS15" loc="BB31" />
-		<pin index="129" name="fmcp1_la23_p" iostandard="LVCMOS15" loc="BA31" />
-		<pin index="130" name="fmcp1_la24_n" iostandard="LVCMOS15" loc="BA34" />
-		<pin index="131" name="fmcp1_la24_p" iostandard="LVCMOS15" loc="AY35" />
-		<pin index="132" name="fmcp1_la25_n" iostandard="LVCMOS15" loc="AY31" />
-		<pin index="133" name="fmcp1_la25_p" iostandard="LVCMOS15" loc="AY30" />
-		<pin index="134" name="fmcp1_la26_n" iostandard="LVCMOS15" loc="BA32" />
-		<pin index="135" name="fmcp1_la26_p" iostandard="LVCMOS15" loc="AY32" />
-		<pin index="136" name="fmcp1_la27_n" iostandard="LVCMOS15" loc="BB30" />
-		<pin index="137" name="fmcp1_la27_p" iostandard="LVCMOS15" loc="BB29" />
-		<pin index="138" name="fmcp1_la28_n" iostandard="LVCMOS15" loc="AU31" />
-		<pin index="139" name="fmcp1_la28_p" iostandard="LVCMOS15" loc="AT32" />
-		<pin index="140" name="fmcp1_la29_n" iostandard="LVCMOS15" loc="AY34" />
-		<pin index="141" name="fmcp1_la29_p" iostandard="LVCMOS15" loc="AW34" />
-		<pin index="142" name="fmcp1_la30_n" iostandard="LVCMOS15" loc="AU30" />
-		<pin index="143" name="fmcp1_la30_p" iostandard="LVCMOS15" loc="AT31" />
-		<pin index="144" name="fmcp1_la31_n" iostandard="LVCMOS15" loc="AT36" />
-		<pin index="145" name="fmcp1_la31_p" iostandard="LVCMOS15" loc="AR36" />
-		<pin index="146" name="fmcp1_la32_n" iostandard="LVCMOS15" loc="AW35" />
-		<pin index="147" name="fmcp1_la32_p" iostandard="LVCMOS15" loc="AV35" />
-		<pin index="148" name="fmcp1_la33_n" iostandard="LVCMOS15" loc="AW33" />
-		<pin index="149" name="fmcp1_la33_p" iostandard="LVCMOS15" loc="AW32" />
+		<pin index="82" name="fmcp1_la00_cc_n" iostandard="MIPI_DPHY" loc="AW37" />
+		<pin index="83" name="fmcp1_la00_cc_p" iostandard="MIPI_DPHY" loc="AV36" />
+		<pin index="84" name="fmcp1_la01_cc_n" iostandard="MIPI_DPHY" loc="AY40" />
+		<pin index="85" name="fmcp1_la01_cc_p" iostandard="MIPI_DPHY" loc="AW40" />
+		<pin index="86" name="fmcp1_la02_n" iostandard="LVCMOS12" loc="AT42" />
+		<pin index="87" name="fmcp1_la02_p" iostandard="LVCMOS12" loc="AR42" />
+		<pin index="88" name="fmcp1_la03_n" iostandard="LVCMOS12" loc="BB36" />
+		<pin index="89" name="fmcp1_la03_p" iostandard="LVCMOS12" loc="BA36" />
+		<pin index="90" name="fmcp1_la04_n" iostandard="LVCMOS12" loc="BA37" />
+		<pin index="91" name="fmcp1_la04_p" iostandard="LVCMOS12" loc="AY36" />
+		<pin index="92" name="fmcp1_la05_n" iostandard="LVCMOS12" loc="AT38" />
+		<pin index="93" name="fmcp1_la05_p" iostandard="LVCMOS12" loc="AR39" />
+		<pin index="94" name="fmcp1_la06_n" iostandard="LVCMOS12" loc="AT37" />
+		<pin index="95" name="fmcp1_la06_p" iostandard="LVCMOS12" loc="AR37" />
+		<pin index="96" name="fmcp1_la07_n" iostandard="MIPI_DPHY" loc="BA38" />
+		<pin index="97" name="fmcp1_la07_p" iostandard="MIPI_DPHY" loc="AY37" />
+		<pin index="98" name="fmcp1_la08_n" iostandard="MIPI_DPHY" loc="AW39" />
+		<pin index="99" name="fmcp1_la08_p" iostandard="MIPI_DPHY" loc="AV38" />
+		<pin index="100" name="fmcp1_la09_n" iostandard="LVCMOS12" loc="AT41" />
+		<pin index="101" name="fmcp1_la09_p" iostandard="LVCMOS12" loc="AR41" />
+		<pin index="102" name="fmcp1_la10_n" iostandard="MIPI_DPHY" loc="AT39" />
+		<pin index="103" name="fmcp1_la10_p" iostandard="MIPI_DPHY" loc="AR40" />
+		<pin index="104" name="fmcp1_la11_n" iostandard="LVCMOS12" loc="BB40" />
+		<pin index="105" name="fmcp1_la11_p" iostandard="LVCMOS12" loc="BA41" />
+		<pin index="106" name="fmcp1_la12_n" iostandard="LVCMOS12" loc="AW38" />
+		<pin index="107" name="fmcp1_la12_p" iostandard="LVCMOS12" loc="AV37" />
+		<pin index="108" name="fmcp1_la13_n" iostandard="LVCMOS12" loc="BA39" />
+		<pin index="109" name="fmcp1_la13_p" iostandard="LVCMOS12" loc="AY39" />
+		<pin index="110" name="fmcp1_la14_n" iostandard="LVCMOS12" loc="AW42" />
+		<pin index="111" name="fmcp1_la14_p" iostandard="LVCMOS12" loc="AV42" />
+		<pin index="112" name="fmcp1_la15_n" iostandard="LVCMOS12" loc="BB39" />
+		<pin index="113" name="fmcp1_la15_p" iostandard="LVCMOS12" loc="BB38" />
+		<pin index="114" name="fmcp1_la16_n" iostandard="LVCMOS12" loc="AY42" />
+		<pin index="115" name="fmcp1_la16_p" iostandard="LVCMOS12" loc="AY41" />
+		<pin index="116" name="fmcp1_la17_cc_n" iostandard="MIPI_DPHY" loc="AW30" />
+		<pin index="117" name="fmcp1_la17_cc_p" iostandard="MIPI_DPHY" loc="AV30" />
+		<pin index="118" name="fmcp1_la18_cc_n" iostandard="MIPI_DPHY" loc="AU36" />
+		<pin index="119" name="fmcp1_la18_cc_p" iostandard="MIPI_DPHY" loc="AU35" />
+		<pin index="120" name="fmcp1_la19_n" iostandard="MIPI_DPHY" loc="AR32" />
+		<pin index="121" name="fmcp1_la19_p" iostandard="MIPI_DPHY" loc="AP32" />
+		<pin index="122" name="fmcp1_la20_n" iostandard="MIPI_DPHY" loc="AT34" />
+		<pin index="123" name="fmcp1_la20_p" iostandard="MIPI_DPHY" loc="AR34" />
+		<pin index="124" name="fmcp1_la21_n" iostandard="MIPI_DPHY" loc="BB33" />
+		<pin index="125" name="fmcp1_la21_p" iostandard="MIPI_DPHY" loc="BA33" />
+		<pin index="126" name="fmcp1_la22_n" iostandard="LVCMOS12" loc="BB35" />
+		<pin index="127" name="fmcp1_la22_p" iostandard="LVCMOS12" loc="BB34" />
+		<pin index="128" name="fmcp1_la23_n" iostandard="LVCMOS12" loc="BB31" />
+		<pin index="129" name="fmcp1_la23_p" iostandard="LVCMOS12" loc="BA31" />
+		<pin index="130" name="fmcp1_la24_n" iostandard="LVCMOS12" loc="BA34" />
+		<pin index="131" name="fmcp1_la24_p" iostandard="LVCMOS12" loc="AY35" />
+		<pin index="132" name="fmcp1_la25_n" iostandard="LVCMOS12" loc="AY31" />
+		<pin index="133" name="fmcp1_la25_p" iostandard="LVCMOS12" loc="AY30" />
+		<pin index="134" name="fmcp1_la26_n" iostandard="LVCMOS12" loc="BA32" />
+		<pin index="135" name="fmcp1_la26_p" iostandard="LVCMOS12" loc="AY32" />
+		<pin index="136" name="fmcp1_la27_n" iostandard="LVCMOS12" loc="BB30" />
+		<pin index="137" name="fmcp1_la27_p" iostandard="LVCMOS12" loc="BB29" />
+		<pin index="138" name="fmcp1_la28_n" iostandard="LVCMOS12" loc="AU31" />
+		<pin index="139" name="fmcp1_la28_p" iostandard="LVCMOS12" loc="AT32" />
+		<pin index="140" name="fmcp1_la29_n" iostandard="LVCMOS12" loc="AY34" />
+		<pin index="141" name="fmcp1_la29_p" iostandard="LVCMOS12" loc="AW34" />
+		<pin index="142" name="fmcp1_la30_n" iostandard="LVCMOS12" loc="AU30" />
+		<pin index="143" name="fmcp1_la30_p" iostandard="LVCMOS12" loc="AT31" />
+		<pin index="144" name="fmcp1_la31_n" iostandard="LVCMOS12" loc="AT36" />
+		<pin index="145" name="fmcp1_la31_p" iostandard="LVCMOS12" loc="AR36" />
+		<pin index="146" name="fmcp1_la32_n" iostandard="LVCMOS12" loc="AW35" />
+		<pin index="147" name="fmcp1_la32_p" iostandard="LVCMOS12" loc="AV35" />
+		<pin index="148" name="fmcp1_la33_n" iostandard="LVCMOS12" loc="AW33" />
+		<pin index="149" name="fmcp1_la33_p" iostandard="LVCMOS12" loc="AW32" />
 		<pin index="150" name="fmcp1_dp0_c2m_p" iostandard="LVCMOS15" loc="K36" />
 		<pin index="151" name="fmcp1_dp0_c2m_n" iostandard="LVCMOS15" loc="K37" />
 		<pin index="152" name="fmcp1_dp0_m2c_p" iostandard="LVCMOS15" loc="J39" />
@@ -289,21 +289,21 @@
 		<pin index="179" name="fmcp1_dp7_c2m_n" iostandard="LVCMOS15" loc="A35" />
 		<pin index="180" name="fmcp1_dp7_m2c_p" iostandard="LVCMOS15" loc="A39" />
 		<pin index="181" name="fmcp1_dp7_m2c_n" iostandard="LVCMOS15" loc="A40" />
-		<pin index="182" name="fmcp1_clk0_m2c_n" iostandard="LVDS_15" loc="AP38" />
-		<pin index="183" name="fmcp1_clk0_m2c_p" iostandard="LVDS_15" loc="AP37" />
-		<pin index="184" name="fmcp1_clk1_m2c_n" iostandard="LVDS_15" loc="AR31" />
-		<pin index="185" name="fmcp1_clk1_m2c_p" iostandard="LVDS_15" loc="AR30" />
+		<pin index="182" name="fmcp1_clk0_m2c_n" iostandard="DIFF_SSTL12" loc="AP38" />
+		<pin index="183" name="fmcp1_clk0_m2c_p" iostandard="DIFF_SSTL12" loc="AP37" />
+		<pin index="184" name="fmcp1_clk1_m2c_n" iostandard="DIFF_SSTL12" loc="AR31" />
+		<pin index="185" name="fmcp1_clk1_m2c_p" iostandard="DIFF_SSTL12" loc="AR30" />
 		<pin index="186" name="fmcp1_gbtclk0_m2c_p" iostandard="LVCMOS15" loc="W32" />
 		<pin index="187" name="fmcp1_gbtclk0_m2c_n" iostandard="LVCMOS15" loc="W33" />
 		<pin index="188" name="fmcp1_gbtclk1_m2c_p" iostandard="LVCMOS15" loc="N34" />
 		<pin index="189" name="fmcp1_gbtclk1_m2c_n" iostandard="LVCMOS15" loc="N35" />
 
-		<pin index="190" name="fmcp1_sync_c2m_n" iostandard="LVCMOS15" loc="AN38" />
-		<pin index="191" name="fmcp1_sync_c2m_p" iostandard="LVCMOS15" loc="AM39" />
-		<pin index="192" name="fmcp1_refclk_c2m_n" iostandard="LVDS_15" loc="AN37" />
-		<pin index="193" name="fmcp1_refclk_c2m_p" iostandard="LVDS_15" loc="AM38" />
-		<pin index="194" name="fmcp1_sync_m2c_n" iostandard="LVCMOS15" loc="AV41" />
-		<pin index="195" name="fmcp1_sync_m2c_p" iostandard="LVCMOS15" loc="AU41" />
+		<pin index="190" name="fmcp1_sync_c2m_n" iostandard="LVCMOS12" loc="AN38" />
+		<pin index="191" name="fmcp1_sync_c2m_p" iostandard="LVCMOS12" loc="AM39" />
+		<pin index="192" name="fmcp1_refclk_c2m_n" iostandard="DIFF_SSTL12" loc="AN37" />
+		<pin index="193" name="fmcp1_refclk_c2m_p" iostandard="DIFF_SSTL12" loc="AM38" />
+		<pin index="194" name="fmcp1_sync_m2c_n" iostandard="LVCMOS12" loc="AV41" />
+		<pin index="195" name="fmcp1_sync_m2c_p" iostandard="LVCMOS12" loc="AU41" />
 		<pin index="196" name="fmcp1_refclk_m2c_n" iostandard="LVDS_15" loc="AT9" />
 		<pin index="197" name="fmcp1_refclk_m2c_p" iostandard="LVDS_15" loc="AR9" />
 		
@@ -511,7 +511,7 @@
 		<pin index="563" name="lpddr4_2_dmi1" loc="AR19" />
 		<pin index="564" name="lpddr4_2_dmi2" loc="AV17" />
 		<pin index="565" name="lpddr4_2_dmi3" loc="BA16" />
-		<pin index="566" name="lpddr4_2_reset_n" iostandard="LVCMOS15" loc="AU33" />
+		<pin index="566" name="lpddr4_2_reset_n" iostandard="LVCMOS12" loc="AU33" />
 		<!-- LPDDR4_Channel_3 -->
 		<pin index="567" name="lpddr4_3_dq0" loc="AK25" />
 		<pin index="568" name="lpddr4_3_dq1" loc="AL26" />
@@ -579,7 +579,7 @@
 		<pin index="630" name="lpddr4_3_dmi1" loc="AW23" />
 		<pin index="631" name="lpddr4_3_dmi2" loc="AM28" />
 		<pin index="632" name="lpddr4_3_dmi3" loc="AY26" />
-		<pin index="633" name="lpddr4_3_reset_n" iostandard="LVCMOS15" loc="AT33" />
+		<pin index="633" name="lpddr4_3_reset_n" iostandard="LVCMOS12" loc="AT33" />
 		<!-- LPDDR4_Channel_4 -->
 		<pin index="700" name="lpddr4_4_dq0" loc="AB41" />
 		<pin index="701" name="lpddr4_4_dq1" loc="Y42" />
@@ -647,7 +647,7 @@
 		<pin index="763" name="lpddr4_4_dmi1" loc="AF42" />
 		<pin index="764" name="lpddr4_4_dmi2" loc="AC37" />
 		<pin index="765" name="lpddr4_4_dmi3" loc="Y36" />
-		<pin index="766" name="lpddr4_4_reset_n" iostandard="LVCMOS15" loc="AV40" />
+		<pin index="766" name="lpddr4_4_reset_n" iostandard="LVCMOS12" loc="AV40" />
 		<!-- LPDDR4_Channel_5 -->
 		<pin index="767" name="lpddr4_5_dq0" loc="AF38" />
 		<pin index="768" name="lpddr4_5_dq1" loc="AF37" />
@@ -715,7 +715,7 @@
 		<pin index="830" name="lpddr4_5_dmi1" loc="AH33" />
 		<pin index="831" name="lpddr4_5_dmi2" loc="AL37" />
 		<pin index="832" name="lpddr4_5_dmi3" loc="AL30" />
-		<pin index="833" name="lpddr4_5_reset_n" iostandard="LVCMOS15" loc="AU40" />
+		<pin index="833" name="lpddr4_5_reset_n" iostandard="LVCMOS12" loc="AU40" />
 		<!-- <pin index="1000" name ="pcie_rx0_n"      loc="AB47"/> -->
 		<!-- <pin index="1001" name ="pcie_rx0_p"      loc="AB46"/> -->
 		<!-- <pin index="1002" name ="pcie_rx1_n"      loc="AA45"/> -->


### PR DESCRIPTION
1. Updated board I/O standard to support MIPI interface
2. Updated connector display name and website details 